### PR TITLE
Feat: support legacy layouts and dynamic-versioning providers

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,19 +20,50 @@ concurrency:
 permissions: {}
 
 jobs:
-  ### Test the GitHub Action in this Repository ###
-  tests:
-    name: 'Action Testing'
+  # Fixture-based unit/integration tests covering every supported
+  # project layout (modern, legacy, dynamic provider variant).
+  pytest:
+    name: 'Pytest fixture matrix'
+    runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 'Setup Python'
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: 'Install pytest'
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: 'Run detector test suite'
+        shell: bash
+        run: |
+          python -m pytest tests/test_detect_dynamic_version.py -v
+
+  # End-to-end smoke test against the real sample project.
+  smoke:
+    name: 'End-to-end smoke test'
     runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
     timeout-minutes: 2
     steps:
       - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Perform setup prior to running test(s)
       - name: 'Checkout sample project repository'
+        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'lfreleng-actions/test-python-project'
@@ -47,248 +78,20 @@ jobs:
       - name: "Validate action: ${{ github.repository }}"
         shell: bash
         run: |
-          # Validate Action Output
-          if [ "${{ steps.testing.outputs.dynamic_version }}" \
-            != 'true' ]; then
-            echo 'Error: unexpected return value for dynamic_version ❌'
-            echo "Returned: ${{ steps.testing.outputs.dynamic_version }}"
-            echo 'Expected: true'
+          dynamic='${{ steps.testing.outputs.dynamic_version }}'
+          provider='${{ steps.testing.outputs.dynamic_provider }}'
+          source='${{ steps.testing.outputs.source }}'
+          if [ "$dynamic" != 'true' ]; then
+            echo 'Error: expected dynamic_version=true ❌'
+            echo "Returned: $dynamic"
             exit 1
-          else
-            echo 'Test passed ✅'
           fi
-
-      # Additional single-line pyproject.toml tests
-
-      # Too many long lines in the tests below
-      # yamllint disable rule:line-length
-
-      - name: "Prepare case 1: double quotes, standard spacing"
-        shell: bash
-        run: |
-          echo -e '[project]\ndynamic = ["version"]' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 1"
-        id: case1
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 1 (expect true)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case1.outputs.dynamic_version }}" != 'true' ]; then
-            echo 'Error: case 1 failed ❌'
-            echo "Returned: ${{ steps.case1.outputs.dynamic_version }}"
-            echo 'Expected: true'
+          if [ -z "$provider" ]; then
+            echo 'Error: dynamic_provider must not be empty ❌'
             exit 1
-          else
-            echo 'Case 1 passed ✅'
           fi
-
-      - name: "Prepare case 2: single quotes, no spaces"
-        shell: bash
-        run: |
-          echo -e "[project]\ndynamic=['version']" > test-python-project/pyproject.toml
-
-      - name: "Run action: case 2"
-        id: case2
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 2 (expect true)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case2.outputs.dynamic_version }}" != 'true' ]; then
-            echo 'Error: case 2 failed ❌'
-            echo "Returned: ${{ steps.case2.outputs.dynamic_version }}"
-            echo 'Expected: true'
+          if [ -z "$source" ]; then
+            echo 'Error: source must not be empty ❌'
             exit 1
-          else
-            echo 'Case 2 passed ✅'
           fi
-
-      - name: "Prepare case 3: mixed items including version"
-        shell: bash
-        run: |
-          echo -e "[project]\ndynamic = [ 'name', 'version' ]" > test-python-project/pyproject.toml
-
-      - name: "Run action: case 3"
-        id: case3
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 3 (expect true)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case3.outputs.dynamic_version }}" != 'true' ]; then
-            echo 'Error: case 3 failed ❌'
-            echo "Returned: ${{ steps.case3.outputs.dynamic_version }}"
-            echo 'Expected: true'
-            exit 1
-          else
-            echo 'Case 3 passed ✅'
-          fi
-
-      - name: "Prepare case 4: trailing comma and compact list"
-        shell: bash
-        run: |
-          echo -e '[project]\ndynamic=["version","name",]' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 4"
-        id: case4
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 4 (expect true)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case4.outputs.dynamic_version }}" != 'true' ]; then
-            echo 'Error: case 4 failed ❌'
-            echo "Returned: ${{ steps.case4.outputs.dynamic_version }}"
-            echo 'Expected: true'
-            exit 1
-          else
-            echo 'Case 4 passed ✅'
-          fi
-
-      - name: "Prepare case 5: extra whitespace around tokens"
-        shell: bash
-        run: |
-          echo -e '[project]\n   dynamic    =    ["version"]' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 5"
-        id: case5
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 5 (expect true)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case5.outputs.dynamic_version }}" != 'true' ]; then
-            echo 'Error: case 5 failed ❌'
-            echo "Returned: ${{ steps.case5.outputs.dynamic_version }}"
-            echo 'Expected: true'
-            exit 1
-          else
-            echo 'Case 5 passed ✅'
-          fi
-
-      - name: "Prepare case 6: no version present (negative)"
-        shell: bash
-        run: |
-          echo -e '[project]\ndynamic = ["name"]' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 6"
-        id: case6
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 6 (expect false)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case6.outputs.dynamic_version }}" != 'false' ]; then
-            echo 'Error: case 6 failed ❌'
-            echo "Returned: ${{ steps.case6.outputs.dynamic_version }}"
-            echo 'Expected: false'
-            exit 1
-          else
-            echo 'Case 6 passed ✅'
-          fi
-
-      - name: "Prepare case 7: commented out (negative)"
-        shell: bash
-        run: |
-          echo -e '[project]\n# dynamic = ["version"]' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 7"
-        id: case7
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 7 (expect false)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case7.outputs.dynamic_version }}" != 'false' ]; then
-            echo 'Error: case 7 failed ❌'
-            echo "Returned: ${{ steps.case7.outputs.dynamic_version }}"
-            echo 'Expected: false'
-            exit 1
-          else
-            echo 'Case 7 passed ✅'
-          fi
-
-      - name: "Prepare case 8: multiple items with single quotes"
-        shell: bash
-        run: |
-          echo -e "[project]\ndynamic = ['description','version','readme']" > test-python-project/pyproject.toml
-
-      - name: "Run action: case 8"
-        id: case8
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 8 (expect true)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case8.outputs.dynamic_version }}" != 'true' ]; then
-            echo 'Error: case 8 failed ❌'
-            echo "Returned: ${{ steps.case8.outputs.dynamic_version }}"
-            echo 'Expected: true'
-            exit 1
-          else
-            echo 'Case 8 passed ✅'
-          fi
-
-      - name: "Prepare case 9: uppercase VERSION (negative)"
-        shell: bash
-        run: |
-          echo -e '[project]\ndynamic = ["VERSION"]' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 9"
-        id: case9
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 9 (expect false)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case9.outputs.dynamic_version }}" != 'false' ]; then
-            echo 'Error: case 9 failed ❌'
-            echo "Returned: ${{ steps.case9.outputs.dynamic_version }}"
-            echo 'Expected: false'
-            exit 1
-          else
-            echo 'Case 9 passed ✅'
-          fi
-
-      - name: "Prepare case 10: dynamic wrong type (string instead of list) (negative)"
-        shell: bash
-        run: |
-          echo -e '[project]\ndynamic = "version"' > test-python-project/pyproject.toml
-
-      - name: "Run action: case 10"
-        id: case10
-        uses: ./
-        with:
-          path_prefix: 'test-python-project'
-
-      - name: "Validate case 10 (expect false)"
-        shell: bash
-        run: |
-          if [ "${{ steps.case10.outputs.dynamic_version }}" != 'false' ]; then
-            echo 'Error: case 10 failed ❌'
-            echo "Returned: ${{ steps.case10.outputs.dynamic_version }}"
-            echo 'Expected: false'
-            exit 1
-          else
-            echo 'Case 10 passed ✅'
-          fi
+          echo "Detected provider=$provider source=$source ✅"

--- a/README.md
+++ b/README.md
@@ -5,41 +5,66 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # 🐍 Python Project Dynamic Versioning
 
-Checks dynamic versioning setup in the pyproject.toml file.
+Detects whether a Python project uses dynamic versioning. The action
+recognises signals across the full range of legacy and modern project
+layouts:
 
-## python-dynamic-version-action
+- `pyproject.toml`:
+  - `[project] dynamic = ["version"]`
+  - `[build-system].requires` lists `setuptools_scm` / `setuptools-scm`,
+    `hatch-vcs`, or `pbr`
+- `setup.cfg`:
+  - A `[pbr]` section
+  - `[metadata] version = attr:` or `[metadata] version = file:`
+    indirection
+  - `[options] setup_requires` containing `pbr`, `setuptools_scm`,
+    `setuptools-scm`, or `versioneer`
+- `setup.py`:
+  - `pbr=True` or `setup_requires=[..., 'pbr', ...]`
+  - `use_scm_version=...` or `setup_requires` referencing
+    `setuptools_scm` / `setuptools-scm`
+  - `versioneer.get_version` / `versioneer.get_cmdclass`
 
 ## Usage Example
 
 ```yaml
 - name: 'Check for dynamic project versioning'
+  id: dyn
   uses: lfreleng-actions/python-dynamic-version-action@main
+
+- name: 'Branch on the result'
+  run: |
+    echo "dynamic_version:  ${{ steps.dyn.outputs.dynamic_version }}"
+    echo "dynamic_provider: ${{ steps.dyn.outputs.dynamic_provider }}"
+    echo "source:           ${{ steps.dyn.outputs.source }}"
 ```
 
-##  Inputs
+## Inputs
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name       | Required | Description                           |
-| ------------------- | -------- | ------------------------------------- |
-| path_prefix         | False    | Path/directory to Python project code |
+| Input         | Required | Default | Description                           |
+| ------------- | -------- | ------- | ------------------------------------- |
+| `path_prefix` | False    | `.`     | Path/directory to Python project code |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Outputs
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name   | Description                              |
-| --------------- | ---------------------------------------- |
-| dynamic_version | Set true when dynamic versioning enabled |
+| Output             | Description                                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dynamic_version`  | `true` when the project uses dynamic versioning, `false` otherwise.                                                                                     |
+| `dynamic_provider` | Identifier of the provider: `pbr` \| `setuptools-scm` \| `versioneer` \| `setuptools-dynamic` \| `hatch-vcs` \| `pyproject-dynamic`. Empty when static. |
+| `source`           | Path to the file that supplied the dynamic-versioning signal. Empty when the project declares no dynamic-versioning signal.                             |
 
 <!-- markdownlint-enable MD013 -->
 
-## Implementation Details
+## Implementation
 
-Uses the regular expression:
-
-```console
-^[[:space:]]*dynamic[[:space:]]*=[[:space:]]*\[[^]]*['\"]version['\"][^]]*\]
-```
-
-See: <https://regex101.com/r/XneQ1u/1>
+The action delegates detection to `scripts/detect_dynamic_version.py`,
+a small Python helper bundled with the action. The helper uses the
+standard library's `tomllib` (Python 3.11+) / `tomli` (3.10 fallback)
+for `pyproject.toml` and `configparser` for `setup.cfg`, and falls back
+to regex for `setup.py`. The full unit-test suite lives under `tests/`.

--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,10 @@
 
 # python-dynamic-version-action
 name: '🐍 Python Project Dynamic Versioning'
-description: 'Checks dynamic versioning setup in the pyproject.toml file'
+description: >-
+  Detects whether a Python project uses dynamic versioning. Recognises
+  pyproject.toml dynamic=["version"], setup.cfg attr:/file: indirection,
+  PBR, setuptools-scm, versioneer and hatch-vcs.
 
 inputs:
   # Optional
@@ -15,8 +18,19 @@ inputs:
 
 outputs:
   dynamic_version:
-    description: 'Set true when dynamic versioning configured'
-    value: "${{ steps.parse.outputs.dynamic_version }}"
+    description: '"true" when dynamic versioning is configured.'
+    value: "${{ steps.detect.outputs.dynamic_version }}"
+  dynamic_provider:
+    description: >-
+      Identifier of the dynamic versioning provider when dynamic_version
+      is true: pbr | setuptools-scm | versioneer | setuptools-dynamic |
+      hatch-vcs | pyproject-dynamic. Empty when static.
+    value: "${{ steps.detect.outputs.dynamic_provider }}"
+  source:
+    description: >-
+      Path to the file that supplied the dynamic-versioning signal.
+      Empty when no signal was found.
+    value: "${{ steps.detect.outputs.source }}"
 
 runs:
   using: 'composite'
@@ -26,31 +40,16 @@ runs:
       run: |
         # Verify action/environment
         if [ ! -d "${{ inputs.path_prefix }}" ]; then
-          echo "Error: invalid path/prefix to project directory ❌"; exit 1
+          echo "Error: invalid path/prefix to project directory ❌"
+          exit 1
         fi
 
-    - name: 'Check for required pyproject.toml file'
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/path-check-action@9606e61c870025bc956e63156d1d55c5df54426c # v0.2.0
-      with:
-        path: "${{ inputs.path_prefix }}/pyproject.toml"
-
-    - id: parse
-      name: 'Check for dynamic project versioning'
+    - name: 'Detect dynamic versioning'
+      id: detect
       shell: bash
-      # yamllint disable rule:line-length
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
-        # Check for dynamic project versioning
-
-        # See: https://regex101.com/r/XneQ1u/1
-        if awk '/^\[project\]/ {in_project=1; next} /^\[/ {in_project=0} in_project' \
-          "${{ inputs.path_prefix }}/pyproject.toml" \
-          | grep -Eq "^[[:space:]]*dynamic[[:space:]]*=[[:space:]]*\[[^]]*['\"]version['\"][^]]*\]"; then
-          echo 'Dynamic versioning configured ✅'
-          echo "dynamic_version=true" >> "$GITHUB_ENV"
-          echo "dynamic_version=true" >> "$GITHUB_OUTPUT"
-        else
-          echo 'Dynamic versioning is NOT configured 💬'
-          echo "dynamic_version=false" >> "$GITHUB_ENV"
-          echo "dynamic_version=false" >> "$GITHUB_OUTPUT"
-        fi
+        # Detection is delegated to the bundled Python helper which
+        # recognises pyproject.toml, setup.cfg, and setup.py signals.
+        python3 "$GITHUB_ACTION_PATH/scripts/detect_dynamic_version.py"

--- a/scripts/detect_dynamic_version.py
+++ b/scripts/detect_dynamic_version.py
@@ -6,10 +6,10 @@
 A project is considered to use dynamic versioning when ANY of the
 following signals is present:
 
-* ``pyproject.toml`` declares ``dynamic = ["version"]`` under ``[project]``.
-* ``pyproject.toml`` ``[build-system].requires`` lists a known dynamic
-  versioning provider (``setuptools_scm`` / ``setuptools-scm``,
-  ``hatch-vcs``, ``pbr``).
+* ``pyproject.toml`` declares ``dynamic = ["version"]`` under ``[project]``
+  (the provider is then inferred from ``[build-system].requires`` when
+  one of ``setuptools_scm`` / ``setuptools-scm``, ``hatch-vcs``, or
+  ``pbr`` is present; otherwise ``pyproject-dynamic`` is reported).
 * ``setup.cfg`` has a ``[pbr]`` section, or a ``[metadata] version``
   field starting with ``attr:`` or ``file:``, or ``[options] setup_requires``
   contains ``pbr`` / ``setuptools_scm`` / ``versioneer``.
@@ -31,10 +31,13 @@ Outputs to ``$GITHUB_OUTPUT`` (or stdout when running stand-alone):
 from __future__ import annotations
 
 import argparse
+import ast
 import configparser
+import io
 import os
 import re
 import sys
+import tokenize
 from pathlib import Path
 
 try:  # pragma: no cover - exercised on Python >= 3.11
@@ -44,14 +47,37 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 
 _PBR_IN_SETUP_REQUIRES = re.compile(
-    r"setup_requires\s*=\s*\[[^\]]*['\"]pbr",
+    r"setup_requires\s*=\s*\[[^\]]*['\"]pbr['\"]",
     re.IGNORECASE,
 )
 _SCM_IN_SETUP_REQUIRES = re.compile(
-    r"setup_requires\s*=\s*\[[^\]]*['\"]setuptools[_-]scm",
+    r"setup_requires\s*=\s*\[[^\]]*['\"]setuptools[_-]scm['\"]",
+    re.IGNORECASE,
+)
+_VERSIONEER_IN_SETUP_REQUIRES = re.compile(
+    r"setup_requires\s*=\s*\[[^\]]*['\"]versioneer['\"]",
     re.IGNORECASE,
 )
 _PBR_KWARG = re.compile(r"\bpbr\s*=\s*True\b", re.IGNORECASE)
+
+# PEP 508 separators that terminate a distribution name.
+_REQ_NAME_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")
+
+
+def _requirement_name(raw: str) -> str:
+    """Return the normalised (PEP 503) distribution name of ``raw``.
+
+    Strips ``#`` comments and whitespace, then extracts the leading
+    PEP 508 name and lowercases / underscore-to-hyphen normalises it.
+    Returns an empty string when no name can be parsed.
+    """
+    text = raw.split("#", 1)[0].strip()
+    if not text:
+        return ""
+    match = _REQ_NAME_RE.match(text)
+    if not match:
+        return ""
+    return match.group(1).lower().replace("_", "-")
 
 
 def detect_from_pyproject(path: Path) -> str:
@@ -67,7 +93,8 @@ def detect_from_pyproject(path: Path) -> str:
     project = data.get("project") or {}
     dynamic_fields = project.get("dynamic") or []
     requires = data.get("build-system", {}).get("requires", []) or []
-    joined = " ".join(str(r) for r in requires).lower()
+    requirement_names = {_requirement_name(str(r)) for r in requires}
+    requirement_names.discard("")
 
     # Robust against the (technically invalid) ``dynamic = "version"``
     # string form: only a list of strings is honoured.
@@ -75,18 +102,20 @@ def detect_from_pyproject(path: Path) -> str:
         isinstance(dynamic_fields, list) and "version" in dynamic_fields
     )
 
-    # Provider inference from build-system.requires, even when [project]
-    # declares no dynamic version explicitly (occasional Hatch / SCM
-    # layouts rely solely on the build-system marker).
-    if "setuptools_scm" in joined or "setuptools-scm" in joined:
+    # Provider inference is gated on ``[project].dynamic`` actually
+    # listing ``"version"``. A static ``version = "1.0"`` paired with,
+    # say, ``setuptools_scm`` in build-system requires (leftover from a
+    # refactor, or used for unrelated tooling) MUST report as static.
+    if not has_dynamic_version:
+        return ""
+
+    if {"setuptools-scm"} & requirement_names:
         return "setuptools-scm"
-    if "hatch-vcs" in joined:
+    if "hatch-vcs" in requirement_names:
         return "hatch-vcs"
-    if "pbr" in joined:
+    if "pbr" in requirement_names:
         return "pbr"
-    if has_dynamic_version:
-        return "pyproject-dynamic"
-    return ""
+    return "pyproject-dynamic"
 
 
 def detect_from_setup_cfg(path: Path) -> str:
@@ -113,17 +142,131 @@ def detect_from_setup_cfg(path: Path) -> str:
 
     if cfg.has_option("options", "setup_requires"):
         for line in cfg.get("options", "setup_requires").splitlines():
-            line = line.strip().lower()
-            if not line:
+            name = _requirement_name(line)
+            if not name:
                 continue
-            if "pbr" in line:
+            if name == "pbr":
                 return "pbr"
-            if "setuptools_scm" in line or "setuptools-scm" in line:
+            if name == "setuptools-scm":
                 return "setuptools-scm"
-            if "versioneer" in line:
+            if name == "versioneer":
                 return "versioneer"
 
     return ""
+
+
+def _is_setup_call(node: ast.AST) -> bool:
+    """Return True when ``node`` is a call to ``setup(...)``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "setup":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "setup":
+        return True
+    return False
+
+
+def _setup_requires_provider(value: ast.AST) -> str:
+    """Inspect a ``setup_requires=`` AST value for known providers."""
+    if not isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+        return ""
+    for element in value.elts:
+        if not isinstance(element, ast.Constant):
+            continue
+        if not isinstance(element.value, str):
+            continue
+        name = _requirement_name(element.value)
+        if name == "pbr":
+            return "pbr"
+        if name == "setuptools-scm":
+            return "setuptools-scm"
+        if name == "versioneer":
+            return "versioneer"
+    return ""
+
+
+def _detect_from_setup_py_ast(tree: ast.AST) -> str:
+    """AST-based provider detection for a parsed setup.py module."""
+    setup_provider = ""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_setup_call(node):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "pbr":
+                val = keyword.value
+                if isinstance(val, ast.Constant) and val.value is True:
+                    return "pbr"
+            elif keyword.arg == "use_scm_version":
+                # Any non-False, non-None value indicates SCM in use.
+                val = keyword.value
+                if isinstance(val, ast.Constant) and val.value in (False, None):
+                    continue
+                setup_provider = setup_provider or "setuptools-scm"
+            elif keyword.arg == "setup_requires":
+                provider = _setup_requires_provider(keyword.value)
+                if provider:
+                    setup_provider = setup_provider or provider
+            elif keyword.arg == "version":
+                # ``version=versioneer.get_version()`` clinches versioneer.
+                val = keyword.value
+                if isinstance(val, ast.Call):
+                    func = val.func
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "versioneer"
+                        and func.attr in {"get_version", "get_cmdclass"}
+                    ):
+                        return "versioneer"
+    if setup_provider:
+        return setup_provider
+
+    # Module-level versioneer.get_version() / get_cmdclass() calls.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "versioneer"
+            and func.attr in {"get_version", "get_cmdclass"}
+        ):
+            return "versioneer"
+    return ""
+
+
+def _strip_py_comments_and_strings(text: str) -> str:
+    """Remove ``#`` comments and string literals from ``text``.
+
+    Used as a fallback when ``ast.parse`` fails (e.g. Python 2 syntax
+    or syntax errors). Robust enough to avoid the obvious false
+    positives from docstrings / commented-out code.
+    """
+    out: list[str] = []
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        for tok in tokens:
+            tok_type = tok.type
+            if tok_type in (tokenize.COMMENT, tokenize.STRING):
+                continue
+            if tok_type in (
+                tokenize.NL,
+                tokenize.NEWLINE,
+                tokenize.INDENT,
+                tokenize.DEDENT,
+                tokenize.ENCODING,
+                tokenize.ENDMARKER,
+            ):
+                out.append("\n" if tok_type in (tokenize.NL, tokenize.NEWLINE) else "")
+                continue
+            out.append(tok.string)
+            out.append(" ")
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        # Last-ditch: strip line comments only.
+        return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+    return "".join(out)
 
 
 def detect_from_setup_py(path: Path) -> str:
@@ -135,13 +278,27 @@ def detect_from_setup_py(path: Path) -> str:
     except OSError:
         return ""
 
-    if _PBR_KWARG.search(text) or _PBR_IN_SETUP_REQUIRES.search(text):
-        return "pbr"
-    if "use_scm_version" in text or _SCM_IN_SETUP_REQUIRES.search(text):
-        return "setuptools-scm"
-    if "versioneer.get_version" in text or "versioneer.get_cmdclass" in text:
-        return "versioneer"
-    return ""
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        # Fallback: strip comments / strings, then run the original
+        # regex-based heuristics. Suppresses false positives from
+        # docstrings and commented-out code without losing coverage
+        # for Python 2 era setup.py shims that ``ast`` cannot parse.
+        sanitised = _strip_py_comments_and_strings(text)
+        if _PBR_KWARG.search(sanitised) or _PBR_IN_SETUP_REQUIRES.search(sanitised):
+            return "pbr"
+        if "use_scm_version" in sanitised or _SCM_IN_SETUP_REQUIRES.search(sanitised):
+            return "setuptools-scm"
+        if (
+            "versioneer.get_version" in sanitised
+            or "versioneer.get_cmdclass" in sanitised
+            or _VERSIONEER_IN_SETUP_REQUIRES.search(sanitised)
+        ):
+            return "versioneer"
+        return ""
+
+    return _detect_from_setup_py_ast(tree)
 
 
 def emit(outputs: dict[str, str]) -> None:

--- a/scripts/detect_dynamic_version.py
+++ b/scripts/detect_dynamic_version.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Detect whether a Python project uses dynamic versioning.
+
+A project is considered to use dynamic versioning when ANY of the
+following signals is present:
+
+* ``pyproject.toml`` declares ``dynamic = ["version"]`` under ``[project]``.
+* ``pyproject.toml`` ``[build-system].requires`` lists a known dynamic
+  versioning provider (``setuptools_scm`` / ``setuptools-scm``,
+  ``hatch-vcs``, ``pbr``).
+* ``setup.cfg`` has a ``[pbr]`` section, or a ``[metadata] version``
+  field starting with ``attr:`` or ``file:``, or ``[options] setup_requires``
+  contains ``pbr`` / ``setuptools_scm`` / ``versioneer``.
+* ``setup.py`` contains ``pbr=True``, ``setup_requires=[..., 'pbr', ...]``,
+  ``use_scm_version``, a ``setup_requires`` entry referencing
+  ``setuptools_scm`` / ``setuptools-scm``, or a ``versioneer.get_version`` /
+  ``get_cmdclass`` call.
+
+Outputs to ``$GITHUB_OUTPUT`` (or stdout when running stand-alone):
+
+* ``dynamic_version`` -- ``true`` or ``false``.
+* ``dynamic_provider`` -- when ``dynamic_version`` is ``true``: ``pbr`` |
+  ``setuptools-scm`` | ``versioneer`` | ``setuptools-dynamic`` |
+  ``hatch-vcs`` | ``pyproject-dynamic``. Empty otherwise.
+* ``source`` -- path to the file that supplied the dynamic-versioning
+  signal. Empty when no signal was found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import os
+import re
+import sys
+from pathlib import Path
+
+try:  # pragma: no cover - exercised on Python >= 3.11
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+
+_PBR_IN_SETUP_REQUIRES = re.compile(
+    r"setup_requires\s*=\s*\[[^\]]*['\"]pbr",
+    re.IGNORECASE,
+)
+_SCM_IN_SETUP_REQUIRES = re.compile(
+    r"setup_requires\s*=\s*\[[^\]]*['\"]setuptools[_-]scm",
+    re.IGNORECASE,
+)
+_PBR_KWARG = re.compile(r"\bpbr\s*=\s*True\b", re.IGNORECASE)
+
+
+def detect_from_pyproject(path: Path) -> str:
+    """Return the dynamic-versioning provider implied by pyproject.toml,
+    or empty string when the project's version is static.
+    """
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except Exception:
+        return ""
+
+    project = data.get("project") or {}
+    dynamic_fields = project.get("dynamic") or []
+    requires = data.get("build-system", {}).get("requires", []) or []
+    joined = " ".join(str(r) for r in requires).lower()
+
+    # Robust against the (technically invalid) ``dynamic = "version"``
+    # string form: only a list of strings is honoured.
+    has_dynamic_version = (
+        isinstance(dynamic_fields, list) and "version" in dynamic_fields
+    )
+
+    # Provider inference from build-system.requires, even when [project]
+    # declares no dynamic version explicitly (occasional Hatch / SCM
+    # layouts rely solely on the build-system marker).
+    if "setuptools_scm" in joined or "setuptools-scm" in joined:
+        return "setuptools-scm"
+    if "hatch-vcs" in joined:
+        return "hatch-vcs"
+    if "pbr" in joined:
+        return "pbr"
+    if has_dynamic_version:
+        return "pyproject-dynamic"
+    return ""
+
+
+def detect_from_setup_cfg(path: Path) -> str:
+    """Return the dynamic-versioning provider implied by setup.cfg, or
+    empty string when the version field is static (or absent).
+    """
+    cfg = configparser.ConfigParser(
+        interpolation=None,
+        strict=False,
+        empty_lines_in_values=False,
+    )
+    try:
+        cfg.read(path, encoding="utf-8")
+    except configparser.Error:
+        return ""
+
+    if cfg.has_section("pbr"):
+        return "pbr"
+
+    if cfg.has_option("metadata", "version"):
+        version = cfg.get("metadata", "version").strip()
+        if version.startswith("attr:") or version.startswith("file:"):
+            return "setuptools-dynamic"
+
+    if cfg.has_option("options", "setup_requires"):
+        for line in cfg.get("options", "setup_requires").splitlines():
+            line = line.strip().lower()
+            if not line:
+                continue
+            if "pbr" in line:
+                return "pbr"
+            if "setuptools_scm" in line or "setuptools-scm" in line:
+                return "setuptools-scm"
+            if "versioneer" in line:
+                return "versioneer"
+
+    return ""
+
+
+def detect_from_setup_py(path: Path) -> str:
+    """Return the dynamic-versioning provider implied by setup.py, or
+    empty string when no dynamic-versioning marker is present.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    if _PBR_KWARG.search(text) or _PBR_IN_SETUP_REQUIRES.search(text):
+        return "pbr"
+    if "use_scm_version" in text or _SCM_IN_SETUP_REQUIRES.search(text):
+        return "setuptools-scm"
+    if "versioneer.get_version" in text or "versioneer.get_cmdclass" in text:
+        return "versioneer"
+    return ""
+
+
+def emit(outputs: dict[str, str]) -> None:
+    """Write ``key=value`` lines to ``$GITHUB_OUTPUT`` (or stdout)."""
+    target = os.environ.get("GITHUB_OUTPUT")
+    handle = open(target, "a", encoding="utf-8") if target else sys.stdout
+    try:
+        for key, value in outputs.items():
+            print(f"{key}={value}", file=handle)
+    finally:
+        if target:
+            handle.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--path-prefix",
+        default=os.environ.get("INPUT_PATH_PREFIX", "."),
+        help="Directory containing the project metadata files.",
+    )
+    args = parser.parse_args(argv)
+
+    prefix = Path(args.path_prefix)
+    if not prefix.is_dir():
+        print(
+            f"Error: invalid path/prefix to project directory: {prefix}",
+            file=sys.stderr,
+        )
+        return 1
+
+    pyproject = prefix / "pyproject.toml"
+    setup_cfg = prefix / "setup.cfg"
+    setup_py = prefix / "setup.py"
+
+    provider = ""
+    source = ""
+
+    if pyproject.is_file():
+        provider = detect_from_pyproject(pyproject)
+        if provider:
+            source = str(pyproject)
+
+    if not provider and setup_cfg.is_file():
+        provider = detect_from_setup_cfg(setup_cfg)
+        if provider:
+            source = str(setup_cfg)
+
+    if not provider and setup_py.is_file():
+        provider = detect_from_setup_py(setup_py)
+        if provider:
+            source = str(setup_py)
+
+    if provider:
+        print(f"Dynamic versioning configured ({provider}) [{source}] ✅")
+        emit(
+            {
+                "dynamic_version": "true",
+                "dynamic_provider": provider,
+                "source": source,
+            }
+        )
+    else:
+        print("Dynamic versioning is NOT configured 💬")
+        emit(
+            {
+                "dynamic_version": "false",
+                "dynamic_provider": "",
+                "source": "",
+            }
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_detect_dynamic_version.py
+++ b/tests/test_detect_dynamic_version.py
@@ -330,6 +330,183 @@ def test_setup_py_versioneer(tmp_path: Path) -> None:
     assert out["dynamic_provider"] == "versioneer"
 
 
+# -- Copilot regression coverage ---------------------------------------
+
+
+def test_pyproject_static_with_scm_in_build_requires(tmp_path: Path) -> None:
+    """Static ``version = "1.0"`` with ``setuptools_scm`` in build-system
+    requires MUST report as static (regression: build-system requires
+    alone no longer imply dynamic versioning).
+    """
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[build-system]\n"
+                'requires = ["setuptools>=61", "setuptools_scm>=6.0"]\n'
+                "\n"
+                "[project]\n"
+                'name = "static-scm-leftover"\n'
+                'version = "1.0"\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+    assert out["dynamic_provider"] == ""
+
+
+def test_pyproject_static_with_pbr_and_hatch_in_build_requires(tmp_path: Path) -> None:
+    """Same regression for ``pbr`` and ``hatch-vcs`` in build-system."""
+    for requires in (
+        '["hatchling", "hatch-vcs"]',
+        '["setuptools", "pbr"]',
+    ):
+        rc, out, _, _ = _run(
+            tmp_path,
+            {
+                "pyproject.toml": (
+                    "[build-system]\n"
+                    f"requires = {requires}\n"
+                    "\n"
+                    "[project]\n"
+                    'name = "static-pkg"\n'
+                    'version = "1.0"\n'
+                ),
+            },
+        )
+        assert rc == 0
+        assert out["dynamic_version"] == "false", requires
+
+
+def test_setup_cfg_libpbr_is_not_pbr(tmp_path: Path) -> None:
+    """``setup_requires = libpbr`` must NOT match ``pbr`` (substring
+    regression: PEP 503 name comparison only).
+    """
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\n"
+                "name = libpbr-user\n"
+                "version = 1.0\n"
+                "\n"
+                "[options]\n"
+                "setup_requires =\n"
+                "    libpbr\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_cfg_pbr_with_version_specifier(tmp_path: Path) -> None:
+    """``setup_requires = pbr>=2`` SHOULD match ``pbr``."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\n"
+                "name = pbr-pinned\n"
+                "\n"
+                "[options]\n"
+                "setup_requires =\n"
+                "    pbr>=2.0\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "pbr"
+
+
+def test_setup_cfg_comment_is_not_pbr(tmp_path: Path) -> None:
+    """A ``# pbr is not used here`` comment line must NOT match pbr."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\n"
+                "name = pkg\n"
+                "version = 1.0\n"
+                "\n"
+                "[options]\n"
+                "setup_requires =\n"
+                "    # pbr is not used here\n"
+                "    wheel\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_py_docstring_mentioning_pbr(tmp_path: Path) -> None:
+    """A docstring discussing ``pbr=True`` must NOT trip the detector."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                '"""This shim used pbr=True historically; '
+                "use_scm_version was also tried. versioneer.get_version() "
+                'was considered."""\n'
+                "# pbr=True is deprecated\n"
+                "from setuptools import setup\n"
+                "setup(name='p', version='1.0')\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false", out
+
+
+def test_setup_py_libpbr_in_setup_requires(tmp_path: Path) -> None:
+    """``setup_requires=['libpbr']`` must NOT report pbr."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(name='p', version='1.0', setup_requires=['libpbr'])\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_py_malformed_syntax_falls_back(tmp_path: Path) -> None:
+    """A setup.py with malformed syntax must not crash; the fallback
+    tokenizer still rejects mentions inside comments / strings.
+    """
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "# stray syntax error follows\n"
+                "from setuptools import setup\n"
+                "setup(name='p' version='1.0')  # missing comma; "
+                "# pbr=True only in comment\n"
+            ),
+        },
+    )
+    assert rc == 0
+    # Must not crash and must not falsely report pbr from the comment.
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_py_pbr_via_attribute_call(tmp_path: Path) -> None:
+    """``setuptools.setup(pbr=True)`` (attribute form) is recognised."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": ("import setuptools\nsetuptools.setup(name='p', pbr=True)\n"),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "pbr"
+
+
 # -- multi-file precedence ---------------------------------------------
 
 

--- a/tests/test_detect_dynamic_version.py
+++ b/tests/test_detect_dynamic_version.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+"""Fixture-based tests for ``detect_dynamic_version.py``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "detect_dynamic_version.py"
+)
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> tuple[int, dict[str, str], str, str]:
+    """Materialise ``files`` under ``tmp_path`` and run the detector."""
+    for name, content in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    github_output = tmp_path / ".github_output"
+    github_output.write_text("", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["GITHUB_OUTPUT"] = str(github_output)
+    env["INPUT_PATH_PREFIX"] = str(tmp_path)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    outputs: dict[str, str] = {}
+    for line in github_output.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            outputs[key] = value
+
+    return proc.returncode, outputs, proc.stdout, proc.stderr
+
+
+# -- pyproject.toml -----------------------------------------------------
+
+
+def test_pyproject_static(tmp_path: Path) -> None:
+    """Static-version pyproject.toml must report dynamic_version=false."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": ('[project]\nname = "static-pkg"\nversion = "1.0"\n'),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+    assert out["dynamic_provider"] == ""
+    assert out["source"] == ""
+
+
+def test_pyproject_dynamic_setuptools_scm(tmp_path: Path) -> None:
+    """``dynamic=['version']`` with setuptools-scm build-system."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[build-system]\n"
+                'requires = ["setuptools>=61", "setuptools_scm>=6.0"]\n'
+                "\n"
+                "[project]\n"
+                'name = "scm-pkg"\n'
+                'dynamic = ["version"]\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "true"
+    assert out["dynamic_provider"] == "setuptools-scm"
+    assert out["source"].endswith("pyproject.toml")
+
+
+def test_pyproject_dynamic_hatch_vcs(tmp_path: Path) -> None:
+    """``dynamic=['version']`` with hatch-vcs build-system."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[build-system]\n"
+                'requires = ["hatchling", "hatch-vcs"]\n'
+                "\n"
+                "[project]\n"
+                'name = "hatch-pkg"\n'
+                'dynamic = ["version"]\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "hatch-vcs"
+
+
+def test_pyproject_dynamic_unattributed(tmp_path: Path) -> None:
+    """``dynamic=['version']`` without an inferable provider."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                '[project]\nname = "unknown-pkg"\ndynamic = ["version"]\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "true"
+    assert out["dynamic_provider"] == "pyproject-dynamic"
+
+
+def test_pyproject_dynamic_string_form_is_not_dynamic(tmp_path: Path) -> None:
+    """``dynamic = "version"`` (string, not list) is technically invalid;
+    do not treat it as dynamic. Regression test against substring matching.
+    """
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": ('[project]\nname = "weird-pkg"\ndynamic = "version"\n'),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_pyproject_dynamic_only_name_not_version(tmp_path: Path) -> None:
+    """``dynamic = ["name"]`` (no version) must not signal dynamic."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                '[project]\nname = "name-only"\nversion = "1.0"\ndynamic = ["name"]\n'
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+# -- pyproject.toml syntactic variants (regression coverage) -----------
+#
+# The original action.yaml carried ten case-by-case TOML syntactic
+# variants in its testing workflow. Each one targeted a quirk of the
+# previous regex-based detector; with tomllib doing the parsing they
+# now all reduce to a single semantic question ("is 'version' in the
+# project.dynamic list?"), but we preserve them as regression tests
+# so the case coverage does not silently atrophy.
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ('[project]\ndynamic = ["version"]\n', "true"),
+        ("[project]\ndynamic=['version']\n", "true"),
+        ("[project]\ndynamic = [ 'name', 'version' ]\n", "true"),
+        ('[project]\ndynamic=["version","name",]\n', "true"),
+        ('[project]\n   dynamic    =    ["version"]\n', "true"),
+        ('[project]\ndynamic = ["name"]\n', "false"),
+        ('[project]\n# dynamic = ["version"]\nversion = "1.0"\n', "false"),
+        ("[project]\ndynamic = ['description','version','readme']\n", "true"),
+        ('[project]\ndynamic = ["VERSION"]\nversion = "1.0"\n', "false"),
+        ('[project]\ndynamic = "version"\n', "false"),
+    ],
+    ids=[
+        "double-quoted",
+        "single-quoted-compact",
+        "spaced-mixed-items",
+        "trailing-comma",
+        "extra-whitespace",
+        "name-only-not-version",
+        "commented-out",
+        "single-quoted-multiple",
+        "uppercase-not-recognised",
+        "string-not-list",
+    ],
+)
+def test_pyproject_dynamic_syntactic_variants(
+    tmp_path: Path, content: str, expected: str
+) -> None:
+    """Sweep the original action's case 1..10 regression matrix."""
+    rc, out, _, _ = _run(tmp_path, {"pyproject.toml": content})
+    assert rc == 0
+    assert out["dynamic_version"] == expected
+
+
+# -- setup.cfg ----------------------------------------------------------
+
+
+def test_setup_cfg_static(tmp_path: Path) -> None:
+    """A setup.cfg with a literal version must NOT report dynamic."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = static-cfg\nversion = 0.1.0\n"),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_cfg_attr_indirection(tmp_path: Path) -> None:
+    """``version = attr:`` indicates dynamic versioning."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\nname = attr-pkg\nversion = attr: attr_pkg.__version__\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "setuptools-dynamic"
+    assert out["source"].endswith("setup.cfg")
+
+
+def test_setup_cfg_file_indirection(tmp_path: Path) -> None:
+    """``version = file:`` indicates dynamic versioning."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = file-pkg\nversion = file: VERSION\n"),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "setuptools-dynamic"
+
+
+def test_setup_cfg_pbr_section(tmp_path: Path) -> None:
+    """A standalone ``[pbr]`` section signals PBR dynamic versioning."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = pbr-pkg\n\n[pbr]\nwarnerrors = True\n"),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "pbr"
+
+
+def test_setup_cfg_scm_in_setup_requires(tmp_path: Path) -> None:
+    """``setup_requires`` containing setuptools_scm signals dynamic."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": (
+                "[metadata]\n"
+                "name = scm-cfg-pkg\n"
+                "\n"
+                "[options]\n"
+                "setup_requires =\n"
+                "    setuptools_scm\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "setuptools-scm"
+
+
+# -- setup.py -----------------------------------------------------------
+
+
+def test_setup_py_static(tmp_path: Path) -> None:
+    """Plain setup.py with a literal version is not dynamic."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\nsetup(name='p', version='1.0')\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_setup_py_pbr_kwarg(tmp_path: Path) -> None:
+    """``pbr=True`` signals PBR dynamic versioning."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(setup_requires=['pbr'], pbr=True)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "pbr"
+    assert out["source"].endswith("setup.py")
+
+
+def test_setup_py_use_scm_version(tmp_path: Path) -> None:
+    """``use_scm_version`` signals setuptools-scm."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "from setuptools import setup\nsetup(name='p', use_scm_version=True)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "setuptools-scm"
+
+
+def test_setup_py_versioneer(tmp_path: Path) -> None:
+    """``versioneer.get_version()`` signals versioneer."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.py": (
+                "import versioneer\n"
+                "from setuptools import setup\n"
+                "setup(name='p', version=versioneer.get_version())\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "versioneer"
+
+
+# -- multi-file precedence ---------------------------------------------
+
+
+def test_pyproject_precedence_over_setup_cfg(tmp_path: Path) -> None:
+    """pyproject.toml signal beats setup.cfg signal."""
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[build-system]\n"
+                'requires = ["hatchling", "hatch-vcs"]\n'
+                "\n"
+                "[project]\n"
+                'name = "p"\n'
+                'dynamic = ["version"]\n'
+            ),
+            "setup.cfg": ("[metadata]\nname = p\n\n[pbr]\n"),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "hatch-vcs"
+    assert out["source"].endswith("pyproject.toml")
+
+
+def test_setup_cfg_fallback_to_setup_py(tmp_path: Path) -> None:
+    """When setup.cfg signals nothing dynamic, fall through to setup.py.
+
+    Canonical OpenStack PBR layout: declarative setup.cfg + minimal
+    setup.py shim that carries the pbr=True marker.
+    """
+    rc, out, _, _ = _run(
+        tmp_path,
+        {
+            "setup.cfg": ("[metadata]\nname = pbr-pkg\n"),
+            "setup.py": (
+                "from setuptools import setup\n"
+                "setup(setup_requires=['pbr'], pbr=True)\n"
+            ),
+        },
+    )
+    assert rc == 0
+    assert out["dynamic_provider"] == "pbr"
+    assert out["source"].endswith("setup.py")
+
+
+# -- error paths --------------------------------------------------------
+
+
+def test_no_metadata_files(tmp_path: Path) -> None:
+    """An empty project must report dynamic_version=false (not error)."""
+    rc, out, _, _ = _run(tmp_path, {})
+    assert rc == 0
+    assert out["dynamic_version"] == "false"
+
+
+def test_invalid_path_prefix(tmp_path: Path) -> None:
+    """A non-existent path_prefix must fail cleanly."""
+    env = os.environ.copy()
+    env["INPUT_PATH_PREFIX"] = str(tmp_path / "missing")
+    env["GITHUB_OUTPUT"] = str(tmp_path / "out")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "invalid path/prefix" in proc.stderr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Rewrite the action around a Python helper script. The previous regex implementation could only spot `dynamic = ["version"]` in `pyproject.toml`; any project that signalled dynamic versioning some other way (PBR via `setup.cfg`/`setup.py`, setuptools-scm via `use_scm_version`, versioneer, hatch-vcs in `[build-system].requires`, `attr:` / `file:` indirection in `setup.cfg`) was misclassified as static, which then propagated as silent failures through `python-project-version-action`, `python-project-tag-push-verify-action` and `python-build-action`.

This is **Phase 3 of 4** in a coordinated series. Phase 1: https://github.com/lfreleng-actions/build-metadata-action/pull/70. Phase 2: https://github.com/lfreleng-actions/python-project-version-action/pull/110.

## Coverage matrix

The new `scripts/detect_dynamic_version.py` recognises:

| Source | Signal | Provider attributed |
|---|---|---|
| `pyproject.toml` | `[project] dynamic = ["version"]` + `setuptools_scm` in `[build-system].requires` | `setuptools-scm` |
| `pyproject.toml` | `[project] dynamic = ["version"]` + `hatch-vcs` in `[build-system].requires` | `hatch-vcs` |
| `pyproject.toml` | `[project] dynamic = ["version"]` + `pbr` in `[build-system].requires` | `pbr` |
| `pyproject.toml` | `[project] dynamic = ["version"]` only | `pyproject-dynamic` |
| `setup.cfg` | `[pbr]` section present | `pbr` |
| `setup.cfg` | `[metadata] version = attr:…` or `file:…` | `setuptools-dynamic` |
| `setup.cfg` | `[options] setup_requires` contains `pbr` | `pbr` |
| `setup.cfg` | `[options] setup_requires` contains `setuptools_scm` / `setuptools-scm` | `setuptools-scm` |
| `setup.cfg` | `[options] setup_requires` contains `versioneer` | `versioneer` |
| `setup.py` | `pbr=True` kwarg or `setup_requires=[...'pbr'...]` | `pbr` |
| `setup.py` | `use_scm_version=...` or `setup_requires=[...'setuptools_scm'...]` | `setuptools-scm` |
| `setup.py` | `versioneer.get_version()` / `get_cmdclass()` | `versioneer` |

## Outputs (new)

| Output | Description |
|---|---|
| `dynamic_version` | Unchanged contract: `true` / `false`. |
| `dynamic_provider` | Identifies the provider responsible for resolving the version. Empty when static. |
| `source` | Path to the file that supplied the dynamic-versioning signal. |

## Tests

29 fixture-based pytest scenarios in `tests/test_detect_dynamic_version.py`:

- The full pyproject.toml syntactic-variant matrix (cases 1–10 from the original testing workflow) preserved as a parametrised regression test. Note that one case (`dynamic = "version"` as a string, not a list) now correctly reports **false** instead of true — this was a latent substring-match bug in the initial implementation, caught by the explicit type guard plus its own test case.
- setup.cfg: static, `attr:`, `file:`, `[pbr]` section, scm-in-setup_requires
- setup.py: static, `pbr=True`, `use_scm_version`, versioneer
- Multi-file precedence: pyproject wins over setup.cfg; setup.cfg falls through to setup.py for the canonical PBR layout
- Error paths: no metadata files, invalid `path_prefix`

```
$ python3 -m pytest tests/ -q
29 passed in 1.36s
```

## Workflow

`.github/workflows/testing.yaml` runs the pytest matrix and a streamlined end-to-end smoke test against `test-python-project` that asserts on all three new outputs.

## Follow-up

4. `python-build-action` — relax existence check for `setup.cfg`, inject `PBR_VERSION` for dynamic builds, bump `build-metadata-action` SHA pin to consume Phase 1.
