### PR TITLE
Fix: resolve Zizmor template-injection finding

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,9 +37,11 @@ runs:
   steps:
     - name: 'Verify action/environment'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Verify action/environment
-        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+        if [ ! -d "$INPUT_PATH_PREFIX" ]; then
           echo "Error: invalid path/prefix to project directory ❌"
           exit 1
         fi


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported a `template-injection`
finding in this composite action. This change resolves it, bringing
the action to zero medium-or-higher findings.

### Changes

- **template-injection:** the "Verify action/environment" step
  interpolated `${{ inputs.path_prefix }}` directly into the bash
  `run` block. The value is now routed through a per-step `env:` block
  (`INPUT_PATH_PREFIX`) and referenced as a quoted shell variable so
  nothing user-controlled is expanded into a run body.

### Impact

No behavioural change.
