### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -87,10 +87,14 @@ jobs:
 
       - name: "Validate action: ${{ github.repository }}"
         shell: bash
+        env:
+          DYNAMIC_VERSION: ${{ steps.testing.outputs.dynamic_version }}
+          DYNAMIC_PROVIDER: ${{ steps.testing.outputs.dynamic_provider }}
+          DYNAMIC_SOURCE: ${{ steps.testing.outputs.source }}
         run: |
-          dynamic='${{ steps.testing.outputs.dynamic_version }}'
-          provider='${{ steps.testing.outputs.dynamic_provider }}'
-          source='${{ steps.testing.outputs.source }}'
+          dynamic="$DYNAMIC_VERSION"
+          provider="$DYNAMIC_PROVIDER"
+          source="$DYNAMIC_SOURCE"
           if [ "$dynamic" != 'true' ]; then
             echo 'Error: expected dynamic_version=true ❌'
             echo "Returned: $dynamic"


### PR DESCRIPTION
## Why

The org-wide zizmor workflow (`lfreleng-actions/.github/workflows/zizmor.yaml`) was changed today:

```
2026-07-28T10:46  Feat: Surface all zizmor findings at any level
```

It runs `--persona auditor --min-severity informational` and now **fails a run on any finding at any level**. This repo carries 3 pre-existing `template-injection` findings, so *every* new PR here is blocked until they're cleared — currently #134.

## What

`.github/workflows/testing.yaml` expanded action outputs directly inside a `run:` block:

```yaml
run: |
  dynamic='${{ steps.testing.outputs.dynamic_version }}'
```

GitHub expands `${{ }}` *before* the shell sees the script, so a crafted value becomes shell source text rather than data. Routing through `env:` makes the value opaque to the shell parser:

```yaml
env:
  DYNAMIC_VERSION: ${{ steps.testing.outputs.dynamic_version }}
run: |
  dynamic="$DYNAMIC_VERSION"
```

Same shape `python-workflows` uses (see its "Fix: Env-mediate expressions in run blocks"), and the `env:`-before-`run:` ordering already used elsewhere here.

## ⚠️ Why this was written by hand

zizmor offers an auto-fix for this audit. It is marked *unsafe*, and on inspection it is — it rewrites the expression in place and leaves it inside the **original single quotes**:

```diff
- dynamic='${{ steps.testing.outputs.dynamic_version }}'
+ dynamic='${STEPS_TESTING_OUTPUTS_DYNAMIC_VERSION}'
```

The shell does not expand `${...}` inside single quotes. The original was correct precisely *because* GitHub expanded the template before the shell ran; once the value moves to `env:`, expansion becomes the shell's job and the quoting has to change with it. Applied as-is, `dynamic` would hold the literal string `${STEPS_...}` and the assertion below would fail.

All three edits here use double quotes and were verified by re-running the audit.

## Validation

- `zizmor --persona auditor --min-severity informational` → **No findings to report**
- `pre-commit run --all-files` → all hooks pass, including `yamllint` and `actionlint`
- No behavioural change: the same values reach the same commands

Unblocks #134.
